### PR TITLE
Closes 12 - Quick fix: empty belongs_to ids crash.

### DIFF
--- a/taglibs/hobo-metasearch.dryml
+++ b/taglibs/hobo-metasearch.dryml
@@ -137,7 +137,7 @@
     <%
       else
       selected = ''
-      selected = clase.find(params[:q][:"#{this.to_s}_id_eq"]).id if params[:q] && params[:q][:"#{this.to_s}_id_eq"]
+      selected = clase.find(params[:q][:"#{this.to_s}_id_eq"]).id if params[:q] && !params[:q][:"#{this.to_s}_id_eq"].blank?
     %>
       <select-menu first-option="" first-value="" name="q[#{this.to_s}_id_eq]" options="&clase.all.map{|o| [o.name, o.id]}" selected="&selected"/>
     <% end %>


### PR DESCRIPTION
Scenario: a User belongs to a Country and a Country has many Users.
In the User index we have table-plus-with-filters and you can filter by Country.
If you just click on Search, hobo-metasearch complains because there is no
such Country with id="nothing".

This is a quick fix, but I think we should enforce the input checking. What
about a regexp to ensure that this parameter is an integer for example?.